### PR TITLE
Always allow standalone login

### DIFF
--- a/pontoon/allauth_urls.py
+++ b/pontoon/allauth_urls.py
@@ -34,6 +34,9 @@ else:
             socialaccount_views.login_error,
             name='socialaccount_login_error'
         ),
+        # Include standalone login even when a social auth provider is enabled
+        url(r'^standalone-login/$', login, name='standalone_login'),
+        url(r'^standalone-logout/$', logout, name='standalone_logout', kwargs={'next_page': '/'}),
     ]
 
 for provider in providers.registry.get_list():


### PR DESCRIPTION
Enable plain Django account logins via `/accounts/standalone-login/`, even when an allauth provider (e.g. Google) is enabled.  

Create Django users with:

```
user@host> manage.py shell
>>> from django.contrib.auth.models import User
>>> user=User.objects.create_user('user_name', password='password')
>>> user.email = 'email@somewhere.com'
>>> user.save()
```

