### PR TITLE
Support "Translate Toolkit" checks for Fluent strings

### DIFF
--- a/frontend/src/core/editor/components/EditorMenu.js
+++ b/frontend/src/core/editor/components/EditorMenu.js
@@ -93,7 +93,7 @@ export default class EditorMenu extends React.Component<Props> {
                             isTranslator={ props.isTranslator }
                             forceSuggestions={ props.user.settings.forceSuggestions }
                             sameExistingTranslation={ props.sameExistingTranslation }
-                            sendTranslation={ props.sendTranslation }
+                            sendTranslation={ () => props.sendTranslation() }
                             updateTranslationStatus={ props.updateTranslationStatus }
                         />
                     </div>

--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -3,6 +3,60 @@ from __future__ import absolute_import
 from . import compare_locales
 from . import translate_toolkit
 from . import pontoon_db, pontoon_non_db
+from fluent.syntax import (
+    ast,
+    FluentParser,
+    FluentSerializer,
+)
+
+
+parser = FluentParser()
+serializer = FluentSerializer()
+
+
+def ftl_to_simplified_string(string):
+    """Take a Fluent entry and extract a simplified string suitable for running Translate Toolkit checks.
+    In particular, pull out text elements, literals, and variable references
+
+
+    :arg string string: a serialized FTL string
+
+    :returns: a simplified (and possibly incomplete) version of the given FTL string
+
+    """
+
+    class TextAndVariableVisitor(ast.Visitor):
+        def __init__(self):
+            self.parts = []
+
+        def visit_StringLiteral(self, literal):
+            self.parts.append(literal.value)
+
+        def visit_NumberLiteral(self, literal):
+            self.parts.append("{}".format(literal.value))
+
+        def visit_TextElement(self, text):
+            self.parts.append(text.value)
+
+        def visit_VariableReference(self, variable):
+            self.parts.append("{{${}}}".format(variable.id.name))
+
+        def visit_Attribute(self, attribute):
+            # Attributes start on a new line. Since we're only taking the text content of the attribute,
+            # prepend a space to ensure that there's whitespace between the preceeding text and the attribute's text
+            self.parts.append(" ")
+            self.generic_visit(attribute)
+
+        def visit_Variant(self, variant):
+            # Variants start on a new line. Since we're only taking the text content of the variant,
+            # prepend a space to ensure that there's whitespace between the preceeding text and the variant's text
+            self.parts.append(" ")
+            self.generic_visit(variant)
+
+    visitor = TextAndVariableVisitor()
+    node = parser.parse_entry(string)
+    visitor.visit(node)
+    return "".join(visitor.parts)
 
 
 def run_checks(
@@ -34,7 +88,7 @@ def run_checks(
     tt_checks = {}
     resource_ext = entity.resource.format
 
-    if use_tt_checks and resource_ext != "ftl":
+    if use_tt_checks:
         # Always disable checks we don't use. For details, see:
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1410619
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1514691
@@ -65,9 +119,33 @@ def run_checks(
         elif resource_ext == "lang":
             tt_disabled_checks.update(["newlines"])
 
-        tt_checks = translate_toolkit.run_checks(
-            original, string, locale_code, tt_disabled_checks
-        )
+        if resource_ext == "ftl":
+            tt_disabled_checks.update(
+                [
+                    "doublespacing",
+                    "endwhitespace",
+                    "escapes",
+                    "newlines",
+                    "numbers",
+                    "printf",
+                    "singlequoting",
+                    "startwhitespace",
+                    "pythonbraceformat",
+                    "doublequoting",
+                ]
+            )
+            tt_checks = translate_toolkit.run_checks(
+                ftl_to_simplified_string(original),
+                ftl_to_simplified_string(string),
+                locale_code,
+                tt_disabled_checks,
+                None,
+                {"varmatches": [("{$", "}")]},
+            )
+        else:
+            tt_checks = translate_toolkit.run_checks(
+                original, string, locale_code, tt_disabled_checks
+            )
 
     checks = dict(tt_checks, **(cl_checks or {}))
 

--- a/pontoon/checks/libraries/translate_toolkit.py
+++ b/pontoon/checks/libraries/translate_toolkit.py
@@ -5,7 +5,14 @@ from translate.lang import data as lang_data
 from translate.storage import base as storage_base
 
 
-def run_checks(original, string, locale_code, disabled_checks=None):
+def run_checks(
+    original,
+    string,
+    locale_code,
+    disabled_checks=None,
+    limit_checks=None,
+    checker_config={},
+):
     """Check for obvious errors like blanks and missing interpunction."""
     original = lang_data.normalized_unicode(original)
     string = lang_data.normalized_unicode(string)
@@ -14,8 +21,11 @@ def run_checks(original, string, locale_code, disabled_checks=None):
     unit = storage_base.TranslationUnit(original)
     unit.target = string
     checker = checks.StandardChecker(
-        checkerconfig=checks.CheckerConfig(targetlanguage=locale_code),
+        checkerconfig=checks.CheckerConfig(
+            targetlanguage=locale_code, **checker_config
+        ),
         excludefilters=disabled_checks,
+        limitfilters=limit_checks,
     )
 
     warnings = checker.run_filters(unit)

--- a/pontoon/checks/tests/test_libraries.py
+++ b/pontoon/checks/tests/test_libraries.py
@@ -305,5 +305,5 @@ def test_tt_checks_simple_ftl(
             "doublequoting",
         },
         None,
-        {"varmatches": [("{ $", " }")]},
+        {"varmatches": [("{$", "}")]},
     )

--- a/pontoon/checks/tests/test_translate_toolkit.py
+++ b/pontoon/checks/tests/test_translate_toolkit.py
@@ -39,3 +39,17 @@ def test_tt_correct_translation(mock_locale):
     Quality check should return empty dictionary if everything is okay (no warnings).
     """
     assert run_checks("Original string", "Translation string", mock_locale) == {}
+
+
+def test_tt_variable(mock_locale):
+    """
+    Variable check should return a warning if variable names do not match
+    """
+    assert run_checks(
+        "Original string with {$variable}.",
+        "Translated string with {$wrongVariable}.",
+        mock_locale,
+        None,
+        {"variables"},
+        {"varmatches": [("{$", "}")]},
+    ) == {"ttWarnings": ["Placeholders"]}


### PR DESCRIPTION
Addresses https://github.com/desmosinc/classroom/issues/11264

Per [this ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1459440), the automated checks for translations have been intentionally disabled for Fluent "because the complexity of the FTL syntax and the way we store FTL strings (together with the key) produces lots of false positives when running Translate Toolkit checks".  This PR implements the approach suggested in that ticket, serializing Fluent strings down to a simplified form--just the plain text elements and variables--before sending them in for Translate Toolkit checks.

<img width="714" alt="Screen Shot 2020-05-13 at 5 18 18 PM" src="https://user-images.githubusercontent.com/4974151/81866880-dce8a800-953d-11ea-96ab-c4b90d21077f.png">

<img width="700" alt="Screen Shot 2020-05-13 at 5 18 57 PM" src="https://user-images.githubusercontent.com/4974151/81866900-e40fb600-953d-11ea-9d07-755c57692a6f.png">


PR submitting this upstream is here: https://github.com/mozilla/pontoon/pull/1628